### PR TITLE
Getters have other getters as second parameter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export function Handler(target: any, key: string) {
  * Vuex getter handler specified in Vuex options.
  */
 export type GetterHandler<TModuleState, TRootState, TResult> =
-    (state: TModuleState, rootState: TRootState) => TResult;
+    (state: TModuleState, getters: any, rootState: TRootState) => TResult;
 
 /**
  * Vuex action handler which takes payload as specified in Vuex options.


### PR DESCRIPTION
As per https://vuex.vuejs.org/guide/modules.html#module-local-state , getters have the other getters as second parameter, so the correct param list is "localState", "getters", "rootState".